### PR TITLE
ci: use PAT for release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Publish release
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             await github.rest.repos.updateRelease({


### PR DESCRIPTION
Use a manually created personal access token so that the release build pipeline can be automatically triggered.