### PR TITLE
feat: add logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.7", features = ["derive"] }
+log = "0.4.20"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 scraper = "0.18.1"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
+stderrlog = { version = "0.5.4", default-features = false }

--- a/src/init.rs
+++ b/src/init.rs
@@ -7,7 +7,7 @@ pub fn init() -> Result<()> {
         true => {
             fs::create_dir_all("content/recipe")?;
             fs::create_dir_all("content/plan")?;
-            println!("Initialized recipe and plan directories.");
+            log::info!("Initialized recipe and plan directories.");
             Ok(())
         }
         false => Err(anyhow::anyhow!("Not a Hugo project. Make sure that the current directory contains a content directory.")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,20 @@ mod parser;
 mod writer;
 use cli::Cli;
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = run() {
+        log::error!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let args = Cli::parse();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(log::Level::Info)
+        .init()
+        .unwrap();
 
     if args.init {
         return init::init();
@@ -51,6 +63,6 @@ fn main() -> Result<()> {
     };
 
     writer::write_recipe(&recipe, &mut output).context("Failed to write recipe.")?;
-    println!("Added recipe {}", &recipe.title);
+    log::info!("Added recipe {}", &recipe.title);
     Ok(())
 }


### PR DESCRIPTION
Use `stderrlog` to output log messages via `stderr`. This prevents informational logging from interfering with the `--stdout` option. Errors are now also handled at the top level and logged in the same way before exiting the application.