### PR TITLE
fix: truncate existing file before writing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn run() -> Result<()> {
         );
         let file = OpenOptions::new()
             .write(true)
+            .truncate(true)
             .create(args.force)
             .create_new(!args.force)
             .open(&file_path);


### PR DESCRIPTION
Add the `truncate` option in file `OpenOptions` to fix issues when the existing file is longer than the newly generated one.